### PR TITLE
Implement whitelist and emergency pause functionality in FixedStakingRewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ FixedStakingRewards is a staking contract that allows users to stake tokens and 
 - **Direct Control**: Owner has direct access to all administrative functions
 - **Reclaim Function**: Owner can recover previously supplied and unclaimed rewards with `reclaim()`
 
+### Whitelist Functionality
+
+- **Permissioned Access**: Only whitelisted addresses can stake tokens and withdraw/claim rewards
+- **Owner-Controlled**: Only owner can add/remove addresses from whitelist
+- **Simple Management**: Add or remove one address at a time with `addToWhitelist()` and `removeFromWhitelist()`
+- **Complete Access Control**: All user operations (stake, withdraw, getReward, exit) require whitelist approval
+
+### Emergency Controls
+
+- **Pausable**: Contract can be paused by owner to halt all user operations in emergencies
+- **Selective Pause**: Only user functions (stake, withdraw, getReward, exit) are paused - owner functions remain active
+- **Emergency Recovery**: Owner can still manage whitelist, rewards, and other admin functions while paused
+
 ## Usage
 
 ### Development Setup

--- a/src/FixedStakingRewards.sol
+++ b/src/FixedStakingRewards.sol
@@ -18,8 +18,9 @@ error RewardsNotAvailableYet(uint256 currentTime, uint256 availableTime);
 error CannotWithdrawZero();
 error CannotWithdrawStakingToken(address attemptedToken);
 error InvalidPriceFeed(uint256 updateTime, int256 currentRewardTokenRate);
+error NotWhitelisted(address account);
 
-contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable {
+contract FixedStakingRewards is IStakingRewards, ERC20Pausable, ReentrancyGuard, Ownable {
     using SafeERC20 for IERC20;
 
     /* ========== STATE VARIABLES ========== */
@@ -36,6 +37,7 @@ contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable
 
     mapping(address => uint256) public userRewardPerTokenPaid;
     mapping(address => uint256) public rewards;
+    mapping(address => bool) public whitelist;
 
     /* ========== CONSTRUCTOR ========== */
 
@@ -67,9 +69,13 @@ contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable
         return rewardRate * 14 days;
     }
 
+    function isWhitelisted(address account) public view returns (bool) {
+        return whitelist[account];
+    }
+
     /* ========== MUTATIVE FUNCTIONS ========== */
 
-    function stake(uint256 amount) external override nonReentrant updateReward(msg.sender) {
+    function stake(uint256 amount) external override nonReentrant updateReward(msg.sender) onlyWhitelisted whenNotPaused {
         if (amount == 0) revert CannotStakeZero();
 
         _rebalance();
@@ -84,7 +90,7 @@ contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable
         emit Staked(msg.sender, amount);
     }
 
-    function withdraw(uint256 amount) public override nonReentrant updateReward(msg.sender) {
+    function withdraw(uint256 amount) public override nonReentrant updateReward(msg.sender) onlyWhitelisted whenNotPaused {
         if (block.timestamp < rewardsAvailableDate) {
             revert RewardsNotAvailableYet(block.timestamp, rewardsAvailableDate);
         }
@@ -97,7 +103,7 @@ contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable
         emit Withdrawn(msg.sender, amount);
     }
 
-    function getReward() public override nonReentrant updateReward(msg.sender) {
+    function getReward() public override nonReentrant updateReward(msg.sender) onlyWhitelisted whenNotPaused {
         if (block.timestamp < rewardsAvailableDate) {
             revert RewardsNotAvailableYet(block.timestamp, rewardsAvailableDate);
         }
@@ -109,7 +115,7 @@ contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable
         }
     }
 
-    function exit() external override {
+    function exit() external override onlyWhitelisted whenNotPaused {
         withdraw(balanceOf(msg.sender));
         getReward();
     }
@@ -151,6 +157,24 @@ contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable
         emit Recovered(tokenAddress, tokenAmount);
     }
 
+    function addToWhitelist(address account) external onlyOwner {
+        whitelist[account] = true;
+        emit WhitelistAdded(account);
+    }
+
+    function removeFromWhitelist(address account) external onlyOwner {
+        whitelist[account] = false;
+        emit WhitelistRemoved(account);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
     /* ========== INTERNAL FUNCTIONS ========== */
     function _rebalance() internal {
         (, int256 currentRewardTokenRate,, uint256 updateTime,) = rewardsTokenRateAggregator.latestRoundData();
@@ -177,6 +201,13 @@ contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable
         _;
     }
 
+    modifier onlyWhitelisted() {
+        if (!whitelist[msg.sender]) {
+            revert NotWhitelisted(msg.sender);
+        }
+        _;
+    }
+
     /* ========== EVENTS ========== */
 
     event RewardAdded(uint256 reward);
@@ -186,4 +217,6 @@ contract FixedStakingRewards is IStakingRewards, ERC20, ReentrancyGuard, Ownable
     event Recovered(address token, uint256 amount);
     event RewardsMadeAvailable(uint256 timestampAvailable);
     event RewardYieldSet(uint256 apy);
+    event WhitelistAdded(address indexed account);
+    event WhitelistRemoved(address indexed account);
 }

--- a/test/FixedStakingRewards.t.sol
+++ b/test/FixedStakingRewards.t.sol
@@ -15,8 +15,11 @@ import {
     RewardsNotAvailableYet,
     CannotWithdrawZero,
     CannotWithdrawStakingToken,
-    InvalidPriceFeed
+    InvalidPriceFeed,
+    NotWhitelisted
 } from "../src/FixedStakingRewards.sol";
+
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 
 contract MockChainlinkAggregator is IChainlinkAggregator {
     uint80 public roundId = 0;
@@ -141,6 +144,10 @@ contract FixedStakingRewardsTest is Test {
     event RewardPaid(address indexed user, uint256 reward);
     event RewardsDurationUpdated(uint256 newDuration);
     event Recovered(address token, uint256 amount);
+    event WhitelistAdded(address indexed account);
+    event WhitelistRemoved(address indexed account);
+    event Paused(address account);
+    event Unpaused(address account);
 
     function setUp() public {
         vm.warp(1000000000);
@@ -212,6 +219,9 @@ contract FixedStakingRewardsTest is Test {
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1000e18);
 
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
         // User stakes
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
@@ -235,6 +245,9 @@ contract FixedStakingRewardsTest is Test {
         // Set up rewards
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         // User stakes
         vm.startPrank(user1);
@@ -267,6 +280,9 @@ contract FixedStakingRewardsTest is Test {
         // Set up rewards so staking is allowed
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1000e18);
+        
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), amount);
@@ -283,6 +299,9 @@ contract FixedStakingRewardsTest is Test {
     }
 
     function test_Stake_RevertWhen_AmountIsZero() public {
+        // Add user to whitelist first
+        stakingRewards.addToWhitelist(user1);
+        
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 0);
 
@@ -292,6 +311,9 @@ contract FixedStakingRewardsTest is Test {
     }
 
     function test_Stake_RevertWhen_InsufficientRewards() public {
+        // Add user to whitelist first
+        stakingRewards.addToWhitelist(user1);
+        
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1e18);
 
@@ -311,6 +333,9 @@ contract FixedStakingRewardsTest is Test {
         // Set up rewards
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         // First stake
         vm.startPrank(user1);
@@ -335,6 +360,9 @@ contract FixedStakingRewardsTest is Test {
         // Set up rewards
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         uint256 rewardsPerHour = 2 * 100e18 * 3600 / uint256(365 days);
 
@@ -375,6 +403,9 @@ contract FixedStakingRewardsTest is Test {
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(2000e18);
 
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
         stakingRewards.stake(100e18);
@@ -389,8 +420,9 @@ contract FixedStakingRewardsTest is Test {
     }
 
     function test_Withdraw_RevertWhen_AmountIsZero() public {
-        // Release rewards first
+        // Release rewards and add user to whitelist first
         stakingRewards.releaseRewards();
+        stakingRewards.addToWhitelist(user1);
 
         vm.startPrank(user1);
         vm.expectRevert(abi.encodeWithSelector(CannotWithdrawZero.selector));
@@ -402,6 +434,9 @@ contract FixedStakingRewardsTest is Test {
         // Set up staking first
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(2000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
@@ -431,6 +466,9 @@ contract FixedStakingRewardsTest is Test {
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(2000e18);
 
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
         stakingRewards.stake(100e18);
@@ -459,6 +497,9 @@ contract FixedStakingRewardsTest is Test {
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(2000e18);
 
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
         stakingRewards.stake(100e18);
@@ -478,6 +519,9 @@ contract FixedStakingRewardsTest is Test {
     //////////////////////////////////////////////////////////////*/
 
     function test_GetReward_RevertWhen_BeforeRewardsAvailableDate() public {
+        // Add user to whitelist first
+        stakingRewards.addToWhitelist(user1);
+        
         vm.startPrank(user1);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -489,8 +533,9 @@ contract FixedStakingRewardsTest is Test {
     }
 
     function test_GetReward_WithNoRewards() public {
-        // Release rewards
+        // Release rewards and add user to whitelist
         stakingRewards.releaseRewards();
+        stakingRewards.addToWhitelist(user1);
 
         vm.startPrank(user1);
         stakingRewards.getReward(); // Should not revert, just do nothing
@@ -501,6 +546,9 @@ contract FixedStakingRewardsTest is Test {
         // Set up staking and rewards
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
@@ -535,6 +583,9 @@ contract FixedStakingRewardsTest is Test {
         // Set up staking and rewards
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
@@ -601,6 +652,9 @@ contract FixedStakingRewardsTest is Test {
         // Set initial reward rate and supply rewards
         stakingRewards.setRewardYieldForYear(1e18); // 1 token per year
         stakingRewards.supplyRewards(5000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         // User stakes
         vm.startPrank(user1);
@@ -708,6 +762,9 @@ contract FixedStakingRewardsTest is Test {
         stakingRewards.supplyRewards(amount);
         uint256 initialBalance = rewardsToken.balanceOf(owner);
 
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
         stakingRewards.stake(100e18);
@@ -767,6 +824,9 @@ contract FixedStakingRewardsTest is Test {
         // Set up staking scenario
         stakingRewards.setRewardYieldForYear(1e18);
         stakingRewards.supplyRewards(1000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
@@ -854,6 +914,9 @@ contract FixedStakingRewardsTest is Test {
         stakingRewards.supplyRewards(1000e18);
         rewardsToken.transfer(address(stakingRewards), 2000e18);
 
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
         stakingRewards.stake(100e18);
@@ -886,6 +949,9 @@ contract FixedStakingRewardsTest is Test {
         // Give user enough tokens
         stakingToken.mint(user1, amount);
 
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), amount);
         stakingRewards.stake(amount);
@@ -903,6 +969,9 @@ contract FixedStakingRewardsTest is Test {
         stakingRewards.setRewardYieldForYear(1e18);
         rewardsToken.transfer(address(stakingRewards), 10000e18);
         stakingToken.mint(user1, stakeAmount);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
 
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), stakeAmount);
@@ -938,28 +1007,31 @@ contract FixedStakingRewardsTest is Test {
         stakingRewards.supplyRewards(1000e18);
         rewardsToken.transfer(address(stakingRewards), 5000e18);
 
-        // 2. User stakes
+        // 2. Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
+        // 3. User stakes
         vm.startPrank(user1);
         stakingToken.approve(address(stakingRewards), 100e18);
         stakingRewards.stake(100e18);
         vm.stopPrank();
 
-        // 3. Time passes
+        // 4. Time passes
         skip(3600);
 
-        // 4. Check earned rewards
+        // 5. Check earned rewards
         uint256 earned = stakingRewards.earned(user1);
         assertEq(earned, 100 * 3600 * (1e18 * 2 / uint256(365 days)));
 
-        // 5. Release rewards
+        // 6. Release rewards
         stakingRewards.releaseRewards();
 
-        // 6. User exits
+        // 7. User exits
         vm.startPrank(user1);
         stakingRewards.exit();
         vm.stopPrank();
 
-        // 7. Verify final state
+        // 8. Verify final state
         assertEq(stakingRewards.balanceOf(user1), 0);
         assertEq(stakingRewards.rewards(user1), 0);
         assertEq(rewardsToken.balanceOf(user1), earned);
@@ -969,6 +1041,10 @@ contract FixedStakingRewardsTest is Test {
         // Set up rewards
         stakingRewards.setRewardYieldForYear(2e18);
         stakingRewards.supplyRewards(1000e18);
+
+        // Add users to whitelist
+        stakingRewards.addToWhitelist(user1);
+        stakingRewards.addToWhitelist(user2);
 
         // User1 stakes
         vm.startPrank(user1);
@@ -997,5 +1073,421 @@ contract FixedStakingRewardsTest is Test {
 
         // Total rewards should be reasonable
         assertApproxEqAbs(user1Earned + user2Earned, 100 * 3600 * 2e18 / uint256(365 days), 1e18);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             WHITELIST TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Whitelist_InitialState() public view {
+        // Initially no addresses should be whitelisted
+        assertFalse(stakingRewards.isWhitelisted(user1));
+        assertFalse(stakingRewards.isWhitelisted(user2));
+        assertFalse(stakingRewards.isWhitelisted(owner));
+    }
+
+    function test_AddToWhitelist_Success() public {
+        vm.expectEmit(true, false, false, true);
+        emit WhitelistAdded(user1);
+
+        stakingRewards.addToWhitelist(user1);
+
+        assertTrue(stakingRewards.isWhitelisted(user1));
+        assertFalse(stakingRewards.isWhitelisted(user2));
+    }
+
+    function test_AddToWhitelist_RevertWhen_NotOwner() public {
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", user1));
+        stakingRewards.addToWhitelist(user2);
+        vm.stopPrank();
+    }
+
+    function test_RemoveFromWhitelist_Success() public {
+        // First add to whitelist
+        stakingRewards.addToWhitelist(user1);
+        assertTrue(stakingRewards.isWhitelisted(user1));
+
+        vm.expectEmit(true, false, false, true);
+        emit WhitelistRemoved(user1);
+
+        stakingRewards.removeFromWhitelist(user1);
+
+        assertFalse(stakingRewards.isWhitelisted(user1));
+    }
+
+    function test_RemoveFromWhitelist_RevertWhen_NotOwner() public {
+        stakingRewards.addToWhitelist(user1);
+
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", user1));
+        stakingRewards.removeFromWhitelist(user1);
+        vm.stopPrank();
+    }
+
+    function test_Stake_RevertWhen_NotWhitelisted() public {
+        // Set up rewards
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, user1));
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+    }
+
+    function test_Stake_SuccessWhen_Whitelisted() public {
+        // Set up rewards
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+
+        // Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+
+        vm.expectEmit(true, true, false, true);
+        emit Staked(user1, 100e18);
+
+        stakingRewards.stake(100e18);
+
+        assertEq(stakingRewards.balanceOf(user1), 100e18);
+        vm.stopPrank();
+    }
+
+    function test_Stake_OnlyWhitelistedUsersCanStake() public {
+        // Set up rewards
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+
+        // Add only user1 to whitelist
+        stakingRewards.addToWhitelist(user1);
+
+        // user1 can stake
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // user2 cannot stake
+        vm.startPrank(user2);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, user2));
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        assertEq(stakingRewards.balanceOf(user1), 100e18);
+        assertEq(stakingRewards.balanceOf(user2), 0);
+    }
+
+    function test_WithdrawAndGetReward_WorkAfterWhitelistRemoval() public {
+        // Set up rewards and whitelist user
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        // User stakes
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // Move time forward and release rewards
+        skip(3600);
+        stakingRewards.releaseRewards();
+
+        // User should be able to withdraw and get rewards while still whitelisted
+        vm.startPrank(user1);
+        stakingRewards.withdraw(50e18);
+        stakingRewards.getReward();
+        vm.stopPrank();
+
+        assertEq(stakingRewards.balanceOf(user1), 50e18);
+        assertGt(rewardsToken.balanceOf(user1), 0);
+    }
+
+    function test_Withdraw_RevertWhen_NotWhitelisted() public {
+        // Set up staking first (user needs to be whitelisted to stake)
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(2000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // Remove user from whitelist and release rewards
+        stakingRewards.removeFromWhitelist(user1);
+        stakingRewards.releaseRewards();
+
+        // User should not be able to withdraw after being removed from whitelist
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, user1));
+        stakingRewards.withdraw(50e18);
+        vm.stopPrank();
+    }
+
+    function test_GetReward_RevertWhen_NotWhitelisted() public {
+        // Set up staking and rewards first
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // Move time forward and release rewards
+        skip(3600);
+        stakingRewards.releaseRewards();
+
+        // Remove user from whitelist
+        stakingRewards.removeFromWhitelist(user1);
+
+        // User should not be able to get rewards after being removed from whitelist
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, user1));
+        stakingRewards.getReward();
+        vm.stopPrank();
+    }
+
+    function test_Exit_RevertWhen_NotWhitelisted() public {
+        // Set up staking first
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // Release rewards and remove from whitelist
+        stakingRewards.releaseRewards();
+        stakingRewards.removeFromWhitelist(user1);
+
+        // User should not be able to exit after being removed from whitelist
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, user1));
+        stakingRewards.exit();
+        vm.stopPrank();
+    }
+
+    function test_Integration_WhitelistFlow() public {
+        // 1. Set up rewards
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+
+        // 2. Add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
+        // 3. User stakes
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // 4. Remove user from whitelist
+        stakingRewards.removeFromWhitelist(user1);
+
+        // 5. User cannot stake more
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        vm.expectRevert(abi.encodeWithSelector(NotWhitelisted.selector, user1));
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // 6. Re-add user to whitelist
+        stakingRewards.addToWhitelist(user1);
+
+        // 7. User can stake again
+        vm.startPrank(user1);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        assertEq(stakingRewards.balanceOf(user1), 200e18);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             PAUSE TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Pause_InitialState() public view {
+        // Contract should not be paused initially
+        assertFalse(stakingRewards.paused());
+    }
+
+    function test_Pause_Success() public {
+        vm.expectEmit(true, false, false, true);
+        emit Paused(owner);
+
+        stakingRewards.pause();
+
+        assertTrue(stakingRewards.paused());
+    }
+
+    function test_Pause_RevertWhen_NotOwner() public {
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", user1));
+        stakingRewards.pause();
+        vm.stopPrank();
+    }
+
+    function test_Unpause_Success() public {
+        // First pause
+        stakingRewards.pause();
+        assertTrue(stakingRewards.paused());
+
+        vm.expectEmit(true, false, false, true);
+        emit Unpaused(owner);
+
+        stakingRewards.unpause();
+
+        assertFalse(stakingRewards.paused());
+    }
+
+    function test_Unpause_RevertWhen_NotOwner() public {
+        stakingRewards.pause();
+
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", user1));
+        stakingRewards.unpause();
+        vm.stopPrank();
+    }
+
+    function test_Stake_RevertWhen_Paused() public {
+        // Set up rewards and whitelist
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        // Pause the contract
+        stakingRewards.pause();
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+
+        vm.expectRevert(abi.encodeWithSelector(Pausable.EnforcedPause.selector));
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+    }
+
+    function test_Withdraw_RevertWhen_Paused() public {
+        // Set up staking first
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(2000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // Release rewards and pause
+        stakingRewards.releaseRewards();
+        stakingRewards.pause();
+
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Pausable.EnforcedPause.selector));
+        stakingRewards.withdraw(50e18);
+        vm.stopPrank();
+    }
+
+    function test_GetReward_RevertWhen_Paused() public {
+        // Set up staking and rewards
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // Move time forward and release rewards
+        skip(3600);
+        stakingRewards.releaseRewards();
+
+        // Pause the contract
+        stakingRewards.pause();
+
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Pausable.EnforcedPause.selector));
+        stakingRewards.getReward();
+        vm.stopPrank();
+    }
+
+    function test_Exit_RevertWhen_Paused() public {
+        // Set up staking first
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // Release rewards and pause
+        stakingRewards.releaseRewards();
+        stakingRewards.pause();
+
+        vm.startPrank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Pausable.EnforcedPause.selector));
+        stakingRewards.exit();
+        vm.stopPrank();
+    }
+
+    function test_OwnerFunctions_WorkWhen_Paused() public {
+        // Owner functions should still work when paused
+        stakingRewards.pause();
+
+        // These should all work
+        stakingRewards.addToWhitelist(user1);
+        stakingRewards.removeFromWhitelist(user1);
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(100e18);
+        stakingRewards.releaseRewards();
+
+        assertTrue(stakingRewards.paused());
+    }
+
+    function test_Integration_PauseUnpauseFlow() public {
+        // 1. Set up rewards and whitelist
+        stakingRewards.setRewardYieldForYear(1e18);
+        stakingRewards.supplyRewards(1000e18);
+        stakingRewards.addToWhitelist(user1);
+
+        // 2. User stakes successfully
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // 3. Pause contract
+        stakingRewards.pause();
+
+        // 4. User cannot stake more
+        vm.startPrank(user1);
+        stakingToken.approve(address(stakingRewards), 100e18);
+        vm.expectRevert(abi.encodeWithSelector(Pausable.EnforcedPause.selector));
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        // 5. Unpause contract
+        stakingRewards.unpause();
+
+        // 6. User can stake again
+        vm.startPrank(user1);
+        stakingRewards.stake(100e18);
+        vm.stopPrank();
+
+        assertEq(stakingRewards.balanceOf(user1), 200e18);
+        assertFalse(stakingRewards.paused());
     }
 }


### PR DESCRIPTION
- Added whitelist feature to restrict staking and reward claiming to approved addresses.
- Introduced emergency pause functionality to halt user operations while allowing owner actions.
- Updated contract methods to enforce whitelist checks and pause conditions.
- Enhanced README documentation to reflect new features and usage instructions.
- Added tests to ensure proper functionality of whitelist and pause mechanisms.